### PR TITLE
Issue/multiple patient entry details

### DIFF
--- a/cspatients/templates/cspatients/patient.html
+++ b/cspatients/templates/cspatients/patient.html
@@ -79,7 +79,7 @@
         </div> 
         {% else %}
         <div>
-            <p>Sorry. No patient such patient was found.</p>
+            <p>Sorry. No such patient was found.</p>
         </div>
         {% endif %}
     </div>

--- a/cspatients/templates/cspatients/patient.html
+++ b/cspatients/templates/cspatients/patient.html
@@ -15,63 +15,63 @@
             </thead>
             <tbody>
                 <tr>
-                    <th scope="row">Name:</td>
+                    <th scope="row">Name:</th>
                     <td>{{ patiententry.patient_id.name }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Hospital ID:</td>
+                    <th scope="row">Hospital ID:</th>
                     <td>{{ patiententry.patient_id.patient_id }}</td> 
                 </tr>
                 <tr>
-                    <th scope="row">Urgency:</td>
+                    <th scope="row">Urgency:</th>
                     <td>{{ patiententry.urgency }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Age:</td>
+                    <th scope="row">Age:</th>
                     <td>{{ patiententry.patient_id.age }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Operation:</td>
+                    <th scope="row">Operation:</th>
                     <td>{{ patiententry.operation }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Location:</td>
+                    <th scope="row">Location:</th>
                     <td>{{ patiententry.location }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Indication:</td>
+                    <th scope="row">Indication:</th>
                     <td>{{ patiententry.indication }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">GravPar:</td>
+                    <th scope="row">GravPar:</th>
                     <td>{{ patiententry.gravpar }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Comorbidities:</td>
+                    <th scope="row">Comorbidities:</th>
                     <td>{{ patiententry.comorbid|default_if_none:"-" }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Responsible Clinician:</td>
+                    <th scope="row">Responsible Clinician:</th>
                     <td>{{ patiententry.clinician|default_if_none:"-"}}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Decision Time:</td>
+                    <th scope="row">Decision Time:</th>
                     <td>{{ patiententry.decision_time|time:"H:i" }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Outstanding Info:</td>
+                    <th scope="row">Outstanding Info:</th>
                     <td>{{ patiententry.outstanding_data|default_if_none:"-" }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Delivery Time:</td>
+                    <th scope="row">Delivery Time:</th>
                     <td>{{ patiententry.delivery_time|time:"H:i" }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">APGAR 1:</td>
+                    <th scope="row">APGAR 1:</th>
                     <td>{{ patiententry.apgar_1|default_if_none:"-" }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">APGAR 5:</td>
+                    <th scope="row">APGAR 5:</th>
                     <td>{{ patiententry.apgar_5|default_if_none:"-" }}</td>
                 </tr>               
             </tbody>

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -312,6 +312,77 @@ class ViewTest(TestCase):
             template_name="cspatients/view.html"
         )
 
+
+class PatientViewTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="Itai"
+        )
+        self.client.force_login(self.user)
+
+    def test_view_non_existing_patient_returns_404(self):
+        response = self.client.get("/cspatients/patient/SHFLFLF")
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(
+            response=response,
+            template_name="cspatients/patient.html"
+        )
+        self.assertInHTML(
+            "Sorry. No patient such patient was found.",
+            str(response.content)
+        )
+
+    def test_view_one_existing_patiententry(self):
+        jane = Patient.objects.create(
+            name="Jane",
+            patient_id="XXXXXX",
+            age=10
+        )
+
+        PatientEntry.objects.create(
+            patient_id=jane,
+            urgency=2,
+            decision_time=timezone.now()
+        )
+
+        response = self.client.get("/cspatients/patient/XXXXXX")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response=response,
+            template_name="cspatients/patient.html"
+        )
+        self.assertInHTML(
+            "Jane",
+            str(response.content)
+        )
+
+    def test_view_two_existing_same_patiententries(self):
+        jane = Patient.objects.create(
+            name="Jane",
+            patient_id="XXXXXX",
+            age=10
+        )
+        PatientEntry.objects.create(
+            patient_id=jane,
+            urgency=2,
+            decision_time=timezone.now(),
+            indication="First Operation"
+        )
+        PatientEntry.objects.create(
+            patient_id=jane,
+            urgency=3,
+            decision_time=timezone.now(),
+            indication="Second Operation"
+        )
+        response = self.client.get("/cspatients/patient/XXXXXX")
+        self.assertEqual(response.status_code, 200)
+        self.assertInHTML(
+            "Second Operation",
+            str(response.content)
+        )
+
 # Util Tests
 
 

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -347,7 +347,9 @@ class PatientViewTest(TestCase):
             decision_time=timezone.now()
         )
 
-        response = self.client.get("/cspatients/patient/XXXXXX")
+        response = self.client.get(
+            "/cspatients/patient/{}".format(jane.patient_id)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
             response=response,
@@ -376,7 +378,9 @@ class PatientViewTest(TestCase):
             decision_time=timezone.now(),
             indication="Second Operation"
         )
-        response = self.client.get("/cspatients/patient/XXXXXX")
+        response = self.client.get(
+            "/cspatients/patient/{}".format(jane.patient_id)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertInHTML(
             "Second Operation",

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -330,7 +330,7 @@ class PatientViewTest(TestCase):
             template_name="cspatients/patient.html"
         )
         self.assertInHTML(
-            "Sorry. No patient such patient was found.",
+            "Sorry. No such patient was found.",
             str(response.content)
         )
 

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -59,19 +59,17 @@ def view(request):
 @login_required(login_url="/cspatients/login")
 def patient(request, patient_id):
     template = loader.get_template("cspatients/patient.html")
-    status_code = 200
-    try:
-        patiententry = PatientEntry.objects.get(patient_id=patient_id)
-    except PatientEntry.MultipleObjectsReturned:
-        patiententry = PatientEntry.objects.order_by('-decision_time')[0]
-    except PatientEntry.DoesNotExist:
-        patiententry = False
-        status_code = 404
+    patiententry = PatientEntry.objects.filter(
+        patient_id=patient_id
+        ).order_by('-decision_time').first()
 
     context = {
         "patiententry": patiententry,
     }
-
+    if patiententry:
+        status_code = 200
+    else:
+        status_code = 404
     return HttpResponse(template.render(context), status=status_code)
 
 

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -59,9 +59,8 @@ def view(request):
 @login_required(login_url="/cspatients/login")
 def patient(request, patient_id):
     template = loader.get_template("cspatients/patient.html")
-    patiententry = PatientEntry.objects.filter(
-        patient_id=patient_id
-        ).order_by('-decision_time').first()
+    patiententry = (PatientEntry.objects.filter(patient_id=patient_id).
+                    order_by('-decision_time').first())
 
     context = {
         "patiententry": patiententry,


### PR DESCRIPTION
When there were multiple patient entries for the same patient, the patient view would raise an error because it used the PatientEntry.objects.get() method which raises an error when there are multiple objects of the same details