### PR TITLE
Add multi select validation endpoint

### DIFF
--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -896,6 +896,44 @@ class WhitelistCheckTestCase(AuthenticatedAPITestCase):
         self.assertEqual(response.json(), {})
 
 
+class MultiSelectTestCase(AuthenticatedAPITestCase):
+    def test_multi_select_valid(self):
+        response = self.normalclient.get(
+            reverse("rp_multiselect"),
+            {"selections": "1, 3,", "options": "test 1, test 2, test 3"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+
+        self.assertEqual(result["valid"], True)
+        self.assertEqual(result["value"], "test 1, test 3")
+
+    def test_multi_select_invalid_selection(self):
+        response = self.normalclient.get(
+            reverse("rp_multiselect"),
+            {"selections": "1,5", "options": "test 1, test 2, test 3"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+
+        self.assertEqual(result["valid"], False)
+        self.assertEqual(result["value"], "")
+
+    def test_multi_select_invalid_character(self):
+        response = self.normalclient.get(
+            reverse("rp_multiselect"),
+            {"selections": "1,a", "options": "test 1, test 2, test 3"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+
+        self.assertEqual(result["valid"], False)
+        self.assertEqual(result["value"], "")
+
+
 class HealthViewTest(APITestCase):
     def setUp(self):
         self.api_client = APIClient()

--- a/cspatients/urls.py
+++ b/cspatients/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
         views.WhitelistCheckView.as_view(),
         name="rp_whitelist_check",
     ),
+    path("api/rpmultiselect", views.MultiSelectView.as_view(), name="rp_multiselect"),
     path("health", views.health, name="health"),
     path("health_details", views.detailed_health, name="detailed-health"),
 ]

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -175,7 +175,7 @@ def clean_and_split_string(str):
     return [x.strip() for x in str.split(",") if x]
 
 
-def is_int(s):
+def can_convert_string_to_int(s):
     try:
         int(s)
         return True

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -169,3 +169,15 @@ def generate_password_reset_url(request, user):
 
     path = reverse("password_reset_confirm", kwargs={"uidb64": uid, "token": token})
     return request.build_absolute_uri(path)
+
+
+def clean_and_split_string(str):
+    return [x.strip() for x in str.split(",") if x]
+
+
+def is_int(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -15,11 +15,11 @@ from .models import Baby, PatientEntry, Profile
 from .serializers import PatientEntrySerializer, PatientSerializer
 from .tasks import post_patient_update
 from .util import (
+    can_convert_string_to_int,
     clean_and_split_string,
     generate_password_reset_url,
     get_all_active_patient_entries,
     get_rp_dict,
-    is_int,
     save_model,
     save_model_changes,
 )
@@ -198,7 +198,7 @@ class MultiSelectView(APIView):
         options = clean_and_split_string(request.GET.get("options", ""))
 
         for item in selections:
-            if not is_int(item):
+            if not can_convert_string_to_int(item):
                 valid = False
             elif int(item) > len(options):
                 valid = False

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -15,9 +15,11 @@ from .models import Baby, PatientEntry, Profile
 from .serializers import PatientEntrySerializer, PatientSerializer
 from .tasks import post_patient_update
 from .util import (
+    clean_and_split_string,
     generate_password_reset_url,
     get_all_active_patient_entries,
     get_rp_dict,
+    is_int,
     save_model,
     save_model_changes,
 )
@@ -192,18 +194,8 @@ class MultiSelectView(APIView):
         valid = True
         selected_items = []
 
-        def clean_and_split(str):
-            return [x.strip() for x in str.split(",") if x]
-
-        def is_int(s):
-            try:
-                int(s)
-                return True
-            except ValueError:
-                return False
-
-        selections = clean_and_split(request.GET.get("selections", ""))
-        options = clean_and_split(request.GET.get("options", ""))
+        selections = clean_and_split_string(request.GET.get("selections", ""))
+        options = clean_and_split_string(request.GET.get("options", ""))
 
         for item in selections:
             if not is_int(item):

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -185,6 +185,42 @@ class WhitelistCheckView(APIView):
         return Response(data, status=return_status)
 
 
+class MultiSelectView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        valid = True
+        selected_items = []
+
+        def clean_and_split(str):
+            return [x.strip() for x in str.split(",") if x]
+
+        def is_int(s):
+            try:
+                int(s)
+                return True
+            except ValueError:
+                return False
+
+        selections = clean_and_split(request.GET.get("selections", ""))
+        options = clean_and_split(request.GET.get("options", ""))
+
+        for item in selections:
+            if not is_int(item):
+                valid = False
+            elif int(item) > len(options):
+                valid = False
+
+        if valid:
+            for item in selections:
+                selected_items.append(options[int(item) - 1])
+
+        return Response(
+            {"valid": valid, "value": ", ".join(selected_items)},
+            status=status.HTTP_200_OK,
+        )
+
+
 def health(request):
     app_id = environ.get("MARATHON_APP_ID", None)
     ver = environ.get("MARATHON_APP_VERSION", None)


### PR DESCRIPTION
RP doesn't support multi select at this point. 

The solution is to have the user enter a comma separated list, we send that and the options to this endpoint to validate and get the text to save.

We do save a comma separated list of values in a string field which is also not ideal but will have to do for now.