### PR TITLE
No duplicate multi select and serialise after update

### DIFF
--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -36,6 +36,24 @@ SAMPLE_RP_POST_DATA = {
     }
 }
 
+SAMPLE_RP_POST_NO_CONSENT_DATA = {
+    "results": {
+        "name": {
+            "category": "All Responses",
+            "value": "(No Consent)",
+            "input": "(No Consent)",
+        },
+        "gravpar": {"category": "All Responses", "value": "AAAA", "input": "AAAA"},
+        "option": {"category": "Patient Entry", "value": "1", "input": "1"},
+        "consent": {
+            "name": "Consent",
+            "category": "no_consent",
+            "value": "2",
+            "input": "2",
+        },
+    }
+}
+
 SAMPLE_RP_UPDATE_DATA = {
     "results": {
         "name": {"category": "All Responses", "value": "Jane Doe", "input": "Jane Doe"},
@@ -600,6 +618,24 @@ class NewPatientAPITestCase(AuthenticatedAPITestCase):
 
         # Check that the Patient, PatientEntry been correctly saved
         self.assertEqual(Patient.objects.get(patient_id="HLFSH").name, "Jane Doe")
+        self.assertEqual(PatientEntry.objects.all().first().gravpar, "G1P0")
+
+    @patch("cspatients.util.get_random_string")
+    def test_new_patient_entry_no_consent(self, mock_random):
+        mock_random.return_value = "1234567890"
+
+        response = self.normalclient.post(
+            reverse("rp_newpatiententry"), SAMPLE_RP_POST_NO_CONSENT_DATA, format="json"
+        )
+
+        # Assert a correct response of 201
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["errors"], "")
+
+        # Check that the Patient, PatientEntry been correctly saved
+        self.assertEqual(
+            Patient.objects.get(patient_id="NO_CONSENT_1234567890").name, "(No Consent)"
+        )
         self.assertEqual(PatientEntry.objects.all().first().gravpar, "G1P0")
 
     def test_new_patient_entry_without_auth(self):

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -228,7 +228,7 @@ class ViewTest(TestCase):
         response = self.client.get(reverse("cspatient_view"))
         self.assertTemplateUsed(response=response, template_name="cspatients/view.html")
 
-    @patch("cspatients.views.get_all_active_patient_entries")
+    @patch("cspatients.util.get_all_active_patient_entries")
     def test_get_view_filter(self, mock_get_patients):
         """
             Test that request is using the filter
@@ -693,6 +693,7 @@ class UpdatePatientEntryAPITestCase(AuthenticatedAPITestCase):
         # Test the right response code
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["errors"], "")
+        self.assertEqual(response.json()["name"], "Nyasha")
 
         # Test that that the change has been made
         patient = Patient.objects.get(patient_id="HLFSH")
@@ -900,7 +901,7 @@ class MultiSelectTestCase(AuthenticatedAPITestCase):
     def test_multi_select_valid(self):
         response = self.normalclient.get(
             reverse("rp_multiselect"),
-            {"selections": "1, 3,", "options": "test 1, test 2, test 3"},
+            {"selections": "1, 3,3, ", "options": "test 1, test 2, test 3"},
         )
         self.assertEqual(response.status_code, 200)
 

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -8,7 +8,11 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
 from .models import Patient, PatientEntry
-from .serializers import CreateEntrySerializer
+from .serializers import (
+    CreateEntrySerializer,
+    PatientEntrySerializer,
+    PatientSerializer,
+)
 
 PATIENT_FIELDS = Patient.__dict__.keys()
 PATIENTENTRY_FIELDS = PatientEntry.__dict__.keys()
@@ -172,7 +176,7 @@ def generate_password_reset_url(request, user):
 
 
 def clean_and_split_string(str):
-    return [x.strip() for x in str.split(",") if x]
+    return [x.strip() for x in str.strip().split(",") if x]
 
 
 def can_convert_string_to_int(s):
@@ -181,3 +185,13 @@ def can_convert_string_to_int(s):
         return True
     except ValueError:
         return False
+
+
+def serialise_patient_entry(patient_entry):
+    patient_entry_serializer = PatientEntrySerializer(patient_entry)
+    patient_serializer = PatientSerializer(patient_entry.patient)
+
+    data = patient_entry_serializer.data
+    data.update(patient_serializer.data)
+
+    return data

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -60,10 +60,13 @@ def get_all_active_patient_entries(search=None, status=None):
                 urgency=status, completion_time__isnull=True
             )
 
+    # latest most urgent on the top, completed at the bottom
     sorted_entries = sorted(
-        patiententrys, key=lambda x: (x.urgency, x.decision_time), reverse=True
+        patiententrys, key=lambda x: (x.decision_time), reverse=True
     )
-    return sorted(sorted_entries, key=lambda x: (x.completion_time is not None))
+    return sorted(
+        sorted_entries, key=lambda x: (x.completion_time is not None, x.urgency)
+    )
 
 
 def send_consumers_table():

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -4,6 +4,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.db.models import Q
 from django.template import loader
 from django.urls import reverse
+from django.utils.crypto import get_random_string
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
@@ -42,6 +43,11 @@ def get_rp_dict(data, context=None):
             final_dict["patient_id"] = all_dict["patient_id"]
         return final_dict
     else:
+        if all_dict.get("consent", "consent_given") == "no_consent":
+            all_dict["patient_id"] = "NO_CONSENT_{}".format(
+                get_random_string(length=10)
+            )
+
         return all_dict
 
 


### PR DESCRIPTION
Users won't be able to enter duplicate items when using the multi select endpoint.

The update endpoint will also return serialised data to update the values displayed in the RP flow.

I also fixed the patient entry order on the triage board.