### PR TITLE
Return serialised data on new entry

### DIFF
--- a/cspatients/serializers.py
+++ b/cspatients/serializers.py
@@ -6,7 +6,7 @@ from cspatients.models import Patient, PatientEntry
 class PatientSerializer(serializers.ModelSerializer):
     class Meta:
         model = Patient
-        exclude = ("created_at", "updated_at", "id", "patient_id")
+        exclude = ("created_at", "updated_at", "id")
 
 
 class PatientEntrySerializer(serializers.ModelSerializer):

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -615,6 +615,7 @@ class NewPatientAPITestCase(AuthenticatedAPITestCase):
         # Assert a correct response of 201
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["errors"], "")
+        self.assertEqual(response.json()["patient_id"], "HLFSH")
 
         # Check that the Patient, PatientEntry been correctly saved
         self.assertEqual(Patient.objects.get(patient_id="HLFSH").name, "Jane Doe")
@@ -631,6 +632,7 @@ class NewPatientAPITestCase(AuthenticatedAPITestCase):
         # Assert a correct response of 201
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["errors"], "")
+        self.assertEqual(response.json()["patient_id"], "NO_CONSENT_1234567890")
 
         # Check that the Patient, PatientEntry been correctly saved
         self.assertEqual(
@@ -687,6 +689,7 @@ class CheckPatientExistsAPITestCase(AuthenticatedAPITestCase):
                 "parity": 0,
                 "age": 20,
                 "foetus": None,
+                "patient_id": "HLFSH",
             },
         )
 
@@ -725,6 +728,7 @@ class CheckPatientExistsAPITestCase(AuthenticatedAPITestCase):
                 "parity": 0,
                 "age": 20,
                 "foetus": None,
+                "patient_id": "HLFSH",
             },
         )
 

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -184,8 +184,8 @@ def generate_password_reset_url(request, user):
     return request.build_absolute_uri(path)
 
 
-def clean_and_split_string(str):
-    return [x.strip() for x in str.strip().split(",") if x]
+def clean_and_split_string(text):
+    return [x.strip() for x in text.strip().split(",") if x]
 
 
 def can_convert_string_to_int(s):

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -77,14 +77,20 @@ def form(request):
 # API VIEWS
 class NewPatientEntryView(APIView):
     def post(self, request):
-        entry, errors = util.save_model(util.get_rp_dict(request.data))
-        if entry:
+        patient_data = {}
+        status_code = status.HTTP_201_CREATED
+
+        patient_entry, errors = util.save_model(util.get_rp_dict(request.data))
+        if patient_entry:
+            patient_data = util.serialise_patient_entry(patient_entry)
+
             post_patient_update.delay()
-            status_code = status.HTTP_201_CREATED
         else:
             status_code = status.HTTP_400_BAD_REQUEST
 
-        return JsonResponse({"errors": ", ".join(errors)}, status=status_code)
+        patient_data["errors"] = ", ".join(errors)
+
+        return JsonResponse(patient_data, status=status_code)
 
 
 class CheckPatientExistsView(APIView):


### PR DESCRIPTION
We're showing the patient ID after saving the patient, as we are now generating a random one for `no consent`, we need to return it back to Rapidpro.

Also renamed a `str` var