### PR TITLE
Make no consent patient ids more readable

### DIFF
--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -632,12 +632,11 @@ class NewPatientAPITestCase(AuthenticatedAPITestCase):
         # Assert a correct response of 201
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["errors"], "")
-        self.assertEqual(response.json()["patient_id"], "NO_CONSENT_1234567890")
+        patient = Patient.objects.last()
+        self.assertEqual(response.json()["patient_id"], f"9{patient.id:07}")
 
         # Check that the Patient, PatientEntry been correctly saved
-        self.assertEqual(
-            Patient.objects.get(patient_id="NO_CONSENT_1234567890").name, "(No Consent)"
-        )
+        self.assertEqual(patient.name, "(No Consent)")
         self.assertEqual(PatientEntry.objects.all().first().gravpar, "G1P0")
 
     def test_new_patient_entry_without_auth(self):

--- a/cspatients/tests.py
+++ b/cspatients/tests.py
@@ -994,6 +994,29 @@ class MultiSelectTestCase(AuthenticatedAPITestCase):
         self.assertEqual(result["value"], "")
 
 
+class PatientListTestCase(AuthenticatedAPITestCase):
+    def create_patient_entry(self, patient_id, name, complete=None):
+        patient = Patient.objects.create(name=name, patient_id=patient_id, age=20)
+        PatientEntry.objects.create(
+            patient=patient, completion_time=complete, indication="indic1"
+        )
+
+    def test_multi_select_valid(self):
+        self.create_patient_entry("00000001", "John Doe")
+        self.create_patient_entry("00000002", "Mary", timezone.now())
+        self.create_patient_entry("00000003", "Test")
+
+        response = self.normalclient.get(reverse("rp_patient_list"))
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+
+        self.assertEqual(
+            result["patient_list"],
+            "00000001 - John Doe CS indic1 Cold\n00000003 - Test CS indic1 Cold",
+        )
+
+
 class HealthViewTest(APITestCase):
     def setUp(self):
         self.api_client = APIClient()

--- a/cspatients/urls.py
+++ b/cspatients/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
         views.WhitelistCheckView.as_view(),
         name="rp_whitelist_check",
     ),
+    path(
+        "api/rppatientlist",
+        views.ActivePatientListView.as_view(),
+        name="rp_patient_list",
+    ),
     path("api/rpmultiselect", views.MultiSelectView.as_view(), name="rp_multiselect"),
     path("health", views.health, name="health"),
     path("health_details", views.detailed_health, name="detailed-health"),

--- a/cspatients/util.py
+++ b/cspatients/util.py
@@ -135,6 +135,10 @@ def save_model(data):
         patient_id=patient_data["patient_id"], defaults=patient_data
     )
 
+    if "NO_CONSENT_" in patient_data["patient_id"]:
+        patient.patient_id = f"9{patient.id:07}"
+        patient.save()
+
     # check if we already have a active entry
     if PatientEntry.objects.filter(
         patient=patient, completion_time__isnull=True

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -234,9 +234,6 @@ class ActivePatientListView(APIView):
                     entry.get_urgency_display(),
                 )
             )
-
-        print(data)
-
         return Response({"patient_list": "\n".join(data)}, status=status.HTTP_200_OK)
 
 

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -215,6 +215,31 @@ class MultiSelectView(APIView):
         )
 
 
+class ActivePatientListView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        entries = PatientEntry.objects.select_related("patient").filter(
+            completion_time__isnull=True
+        )
+
+        data = []
+        for entry in entries:
+            data.append(
+                "{} - {} {} {} {}".format(
+                    entry.patient.patient_id,
+                    entry.patient.name,
+                    entry.operation,
+                    entry.indication,
+                    entry.get_urgency_display(),
+                )
+            )
+
+        print(data)
+
+        return Response({"patient_list": "\n".join(data)}, status=status.HTTP_200_OK)
+
+
 def health(request):
     app_id = environ.get("MARATHON_APP_ID", None)
     ver = environ.get("MARATHON_APP_VERSION", None)


### PR DESCRIPTION
This is temporary to allow them to continue testing today.

The next step would be to change all patient IDs to auto generate.