### PR TITLE
Fix int fields on change

### DIFF
--- a/cspatients/tests/constants.py
+++ b/cspatients/tests/constants.py
@@ -52,6 +52,15 @@ SAMPLE_RP_UPDATE_DATA = {
     }
 }
 
+SAMPLE_RP_UPDATE_URGENCY_DATA = {
+    "results": {
+        "patient_id": {"category": "All Responses", "value": "1", "input": "1"},
+        "new_value": {"category": "All Responses", "value": "1", "input": "1"},
+        "change_category": {"category": "urgency", "value": "1", "input": "1"},
+        "option": {"category": "Patient Entry", "value": "1", "input": "1"},
+    }
+}
+
 SAMPLE_RP_POST_DATA_NON_EXISTING = {
     "results": {
         "name": {"category": "All Responses", "value": "Jane Moe", "input": "Jane Moe"},

--- a/cspatients/tests/test_views.py
+++ b/cspatients/tests/test_views.py
@@ -31,6 +31,7 @@ from .constants import (
     SAMPLE_RP_UPDATE_DELIVERY_DATA_MINIMAL,
     SAMPLE_RP_UPDATE_INVALID_DATA,
     SAMPLE_RP_UPDATE_NONDELIVERY_DATA,
+    SAMPLE_RP_UPDATE_URGENCY_DATA,
 )
 
 
@@ -355,6 +356,27 @@ class UpdatePatientEntryAPITestCase(AuthenticatedAPITestCase):
         # Test that that the change has been made
         self.patiententry.refresh_from_db()
         self.assertTrue(self.patiententry.surname == "Nyasha")
+
+    def test_update_patient_urgency(self):
+        SAMPLE_RP_UPDATE_URGENCY_DATA["results"]["patient_id"]["value"] = str(
+            self.patiententry.id
+        )
+        SAMPLE_RP_UPDATE_URGENCY_DATA["results"]["patient_id"]["input"] = str(
+            self.patiententry.id
+        )
+
+        response = self.normalclient.post(
+            reverse("rp_entrychanges"), SAMPLE_RP_UPDATE_URGENCY_DATA, format="json"
+        )
+
+        # Test the right response code
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["errors"], "")
+        self.assertEqual(response.json()["urgency"], "Immediate (Red)")
+
+        # Test that that the change has been made
+        self.patiententry.refresh_from_db()
+        self.assertEqual(self.patiententry.urgency, 1)
 
     def test_update_patient_invalid_data(self):
         response = self.normalclient.post(

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -123,6 +123,7 @@ class UpdatePatientEntryView(APIView):
         changes_dict = util.get_rp_dict(request.data, context="entrychanges")
         patient_entry, errors = util.save_model_changes(changes_dict)
         if patient_entry:
+            patient_entry.refresh_from_db()
             patient_data = util.serialise_patient_entry(patient_entry)
 
             post_patient_update.delay()


### PR DESCRIPTION
We need to refresh the entry from the database before we serialise, so that the fields will have the correct types.