### PR TITLE
Return -1 instead of 404

### DIFF
--- a/cspatients/tests/test_views.py
+++ b/cspatients/tests/test_views.py
@@ -798,7 +798,10 @@ class PatientSelectTestCase(AuthenticatedAPITestCase):
             {"patient_ids": "1=00000001|2=00000003|3=00000004", "option": "4"},
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertEqual(result["patient_id"], "-1")
 
 
 class WhatsAppEventListenerTest(APITestCase):

--- a/cspatients/views.py
+++ b/cspatients/views.py
@@ -275,10 +275,9 @@ class PatientSelectView(APIView):
 
         patient_ids = dict(item.split("=") for item in id_string.split("|"))
 
-        if option not in patient_ids:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        return Response({"patient_id": patient_ids[option]}, status=status.HTTP_200_OK)
+        return Response(
+            {"patient_id": patient_ids.get(option, "-1")}, status=status.HTTP_200_OK
+        )
 
 
 class WhatsAppEventListener(APIView):


### PR DESCRIPTION
The 404 that is being returned here is being raised by our alerts as a webhook failure. We're now just returning a -1 that we can handle appropriately in the flows.